### PR TITLE
disable Content-Security-Policy-Report-Only header

### DIFF
--- a/nice2.conf
+++ b/nice2.conf
@@ -11,7 +11,6 @@ server {
     add_header Alt-Svc 'h2=":443"; ma=900' always;
 
     add_header Strict-Transport-Security "max-age=63072000;" always; # Force Client to use HTTPS for next 730 days
-    add_header Content-Security-Policy-Report-Only "default-src 'self'; style-src 'self' 'unsafe-inline' data: https://fonts.googleapis.com https://maxcdn.bootstrapcdn.com; font-src 'self' data: https://fonts.google.com https://fonts.gstatic.com https://maxcdn.bootstrapcdn.com; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://ssl.google-analytics.com https://s7.addthis.com https://m.addthis.com https://m.addthisedge.com https://graph.facebook.com https://api-public.addthis.com https://maps.googleapis.com https://www.linkedin.com https://analytics.google.com https://www.google.com https://ssl.gstatic.com; connect-src 'self' https://s7.addthis.com https://m.addthis.com; img-src * data:; child-src 'self' https://manual.tocco.ch https://s7.addthis.com https://docs.google.com https://www.youtube.com https://calendar.google.com https://www.google.com https://www.facebook.com; report-uri https://csp-reports.tocco.ch/r;" always;
     # add_header X-XSS-Protection "1; mode=block" always;  # set by Nice2
     # add_header X-Content-Type-Options "nosniff" always;  # set by Nice2
 


### PR DESCRIPTION
This header needs to be adjusted on a per customer basis.