### PR TITLE
drop ALT-SVC header

### DIFF
--- a/nice2.conf
+++ b/nice2.conf
@@ -8,8 +8,6 @@ server {
     add_header X-AppServer-Status $upstream_status; # Backend HTTP Status
     add_header X-AppServer $upstream_addr; # Backend Server / Port
 
-    add_header Alt-Svc 'h2=":443"; ma=900' always;
-
     add_header Strict-Transport-Security "max-age=63072000;" always; # Force Client to use HTTPS for next 730 days
     # add_header X-XSS-Protection "1; mode=block" always;  # set by Nice2
     # add_header X-Content-Type-Options "nosniff" always;  # set by Nice2


### PR DESCRIPTION
This isn't needed since TLS' ALPN is used to negotiate the protocol.