### PR TITLE
allow header to be set dynamically via environment variables

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+# ignore cached python byte-code
+**/__pycache__/

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,19 +5,18 @@ addons:
   apt:
     packages:
     - python3
+    - python3-requests
 before_install:
   - docker build -t nginx .
-  - docker run -d -u 1234:0 -p 8081:8081 --name nginx nginx
+  - docker run -d -u 1234:0 --net=host -p 8081:8081 --name nginx -e NGINX_HEADER_Some-Header='some "value"'
+       -e NGINX_ALWAYS_HEADER_Some__Always__Header='some always "value"' nginx
   - |
     while ! [[ $(curl -s -o /dev/null -w "%{http_code}" "http://localhost:8081/status-tocco-nginx") = 200 ]]; do
         echo "waiting for Nginx to become ready"
+        docker exec -it nginx true || return
         sleep 1;
     done
-  - docker exec -u 0:0 nginx apt update
-  - docker exec -u 0:0 nginx apt install -y redir
-  - docker exec -d nginx redir --lport 8080 --caddr github.com --cport 80
 script:
   - docker exec nginx nginx -t
-  - |
-    redirect=$(curl -v -s -w "%{redirect_url}" -H "Host: github.com" "http://localhost:8081/tocco/") \
-      && [ "$redirect" = "https://github.com/tocco/" ]
+  - PYTHONPATH=$PWD python3 -m unittest discover tests
+  - ./tests/integration_tests.py

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,15 @@
 from nginx:latest
 ADD nice2.conf /etc/nginx/conf.d/
 ADD nginx.conf /etc/nginx/
-RUN chmod -R 777 /var/log/nginx /var/cache/nginx /var/run \
+ADD header_config.py /usr/local/bin/
+ADD entrypoint /usr/local/bin/
+RUN  apt-get update \
+     && apt-get install -y --no-install-recommends python3 \
+     && rm -r /var/cache/apt/* \
+     && chmod -R 777 /var/log/nginx /var/cache/nginx /var/run \
      && chgrp -R 0 /etc/nginx \
      && chmod -R g+rwX /etc/nginx \
-     && rm /etc/nginx/conf.d/default.conf
+     && rm -f /etc/nginx/conf.d/default.conf \
+     && chmod +x /usr/local/bin/header_config.py /usr/local/bin/entrypoint
 EXPOSE 8081
-ENTRYPOINT ["nginx", "-g", "daemon off;"]
+ENTRYPOINT ["/usr/local/bin/entrypoint"]

--- a/README.md
+++ b/README.md
@@ -1,2 +1,26 @@
 # openshift-nginx
 [![Build Status](https://travis-ci.org/pgerber/openshift-nginx.svg?branch=master)](https://travis-ci.org/pgerber/openshift-nginx)
+
+## Settings Headers
+
+IMPORTANT:
+
+OpenShift does not currently allow hyphens (`-`) to appear as keys of environment variables, you need to use double underscores (`__`)
+instead. (See examples below.)
+
+Set header for responses with 2XX status codes:
+
+```
+    NGINX_HEADER_My__Header=header-content
+```
+
+This creates a header called `My-Header` with the value `header-content`.
+
+
+Set header regardless of status code:
+
+```
+    NGINX_ALWAYS_HEADER_My__Header=header-content
+```
+
+This creates a header called `My-Header` with the value `header-content`.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # openshift-nginx
 [![Build Status](https://travis-ci.org/pgerber/openshift-nginx.svg?branch=master)](https://travis-ci.org/pgerber/openshift-nginx)
 
-## Settings Headers
+## Setting Headers
 
 IMPORTANT:
 

--- a/entrypoint
+++ b/entrypoint
@@ -1,0 +1,9 @@
+#!/usr/bin/python3
+import os
+import subprocess
+
+GLOBAL_DIRECTIVES='daemon off;'
+
+subprocess.check_call(['/usr/local/bin/header_config.py'])
+subprocess.check_call(['nginx', '-t', '-g', GLOBAL_DIRECTIVES])
+os.execvp('nginx', ['nginx', '-g', GLOBAL_DIRECTIVES])

--- a/header_config.py
+++ b/header_config.py
@@ -1,0 +1,59 @@
+#!/usr/bin/python3
+import functools
+import os
+
+
+ENV_PREFIX = 'NGINX_HEADER_'
+ENV_ALWAYS_PREFIX = 'NGINX_ALWAYS_HEADER_'
+QUOTE_TRANSLATION_TABLE = str.maketrans({
+    "\\": r"\\",
+    '"':  r'\"'
+})
+
+
+class Header:
+    def __init__(self, name, value, *, always):
+        self.name = name
+        self.value = value
+        self.always = always
+
+    def line(self):
+        param = ' always' if self.always else ''
+        return "add_header {} {}{};".format(quote(self.name), quote(self.value), param)
+
+
+def quote(value):
+    return '"' + value.translate(QUOTE_TRANSLATION_TABLE) + '"'
+
+
+def unescape(value):
+    return value.replace('__', '-')
+
+
+def extract_headers(env):
+    for key, value in env.items():
+        if key.startswith(ENV_PREFIX):
+            yield Header(unescape(key[len(ENV_PREFIX):]), value, always=False)
+        elif key.startswith(ENV_ALWAYS_PREFIX):
+            yield Header(unescape(key[len(ENV_ALWAYS_PREFIX):]), value, always=True)
+
+
+def write_config(stream, headers):
+    write = functools.partial(print, file=stream)
+    write('# DO NOT EDIT MANUALLY!')
+    write('# content is generated based on NGINX_HEADER_* and NGINX_ALWAYS_HEADER_* environment variables')
+    write()
+    for header in sorted(headers, key=lambda i: i.name):
+        write(header.line())
+
+
+def main(env, path):
+    headers = extract_headers(env)
+    with open(path, 'w') as f:
+        write_config(f, headers)
+
+
+if __name__ == '__main__':
+    print(os.environ)
+    main(os.environ, '/etc/nginx/headers.include')
+

--- a/nice2.conf
+++ b/nice2.conf
@@ -8,9 +8,7 @@ server {
     add_header X-AppServer-Status $upstream_status; # Backend HTTP Status
     add_header X-AppServer $upstream_addr; # Backend Server / Port
 
-    add_header Strict-Transport-Security "max-age=63072000;" always; # Force Client to use HTTPS for next 730 days
-    # add_header X-XSS-Protection "1; mode=block" always;  # set by Nice2
-    # add_header X-Content-Type-Options "nosniff" always;  # set by Nice2
+    include       /etc/nginx/headers.include;
 
     location / {
         if ($request_uri = /status-tocco-nginx) {

--- a/tests/integration_tests.py
+++ b/tests/integration_tests.py
@@ -1,0 +1,41 @@
+#!/usr/bin/python3
+import requests
+import subprocess
+import time
+
+
+def assert_response(path, code, *, some_header):
+    r = requests.get('http://localhost:8081/{}'.format(path))
+
+    assert r.status_code == code, 'got code {} but expected {}'.format(r.status_code, code)
+    assert r.headers['Some-Always-Header'] == 'some always "value"'
+    assert not some_header or r.headers['Some-Header'] == 'some "value"'
+
+
+#
+# Test if status-tocco-nginx returns 200 even if Nice isn't reachable
+#
+assert_response('status-tocco-nginx', 200, some_header=True)
+assert_response('bad-gateway', 502, some_header=False)
+
+
+#
+# Verify forwarding to upstream works and headers are set
+#
+nice_mock = subprocess.Popen('./tests/nice_mock.py')
+
+# wait for mock to become ready
+while True:
+    try:
+        requests.get('http://localhost:8080/200')
+    except requests.exceptions.ConnectionError:
+        print('waiting for mock …')
+        time.sleep(0.5)
+    else:
+        break
+
+assert_response('200', 200, some_header=True)
+assert_response('404', 404, some_header=False)
+assert_response('500', 500, some_header=False)
+
+nice_mock.terminate()

--- a/tests/nice_mock.py
+++ b/tests/nice_mock.py
@@ -1,0 +1,25 @@
+#!/usr/bin/python3
+#
+# Micro web server whose status code is based on the path. Path /200 returns status code 200,
+# /404 code 400 and so on.
+#
+from http.server import BaseHTTPRequestHandler, HTTPServer
+import socketserver
+import os
+
+
+class S(BaseHTTPRequestHandler):
+    def do_GET(self):
+        code = int(self.path[1:])
+        self.send_response(code)
+        self.end_headers()
+
+
+def run(server_class=HTTPServer, handler_class=S):
+    server_address = ('localhost', 8080)
+    httpd = server_class(server_address, handler_class)
+    httpd.serve_forever()
+
+
+if __name__ == "__main__":
+    run()

--- a/tests/test_header_config.py
+++ b/tests/test_header_config.py
@@ -1,0 +1,26 @@
+import header_config
+import tempfile
+import textwrap
+import unittest
+
+class Test(unittest.TestCase):
+    def test_main(self):
+        env = {
+            'NGINX_HEADER_Strict-Transport-Security': 'max-age=86400',
+            'ignored': 'ignored',
+            'NGINX_HEADER_a_name': r'value in need of escaping "\"',
+            'NGINX_HEADER_name-with__hyphens': 'double__underscores__not__replaced__here',
+            'NGINX_ALWAYS_HEADER_Always': 'present even on error pages'
+        }
+        with tempfile.NamedTemporaryFile(mode='w+') as f:
+            header_config.main(env, f.name)
+
+            self.assertEqual(f.read(), textwrap.dedent(r"""
+                # DO NOT EDIT MANUALLY!
+                # content is generated based on NGINX_HEADER_* and NGINX_ALWAYS_HEADER_* environment variables
+
+                add_header "Always" "present even on error pages" always;
+                add_header "Strict-Transport-Security" "max-age=86400";
+                add_header "a_name" "value in need of escaping \"\\\"";
+                add_header "name-with-hyphens" "double__underscores__not__replaced__here";
+            """).lstrip())


### PR DESCRIPTION
• read header to set from environment:
   - NGINX_HEADER_* are set for pages with status code 2xx
   - NGINX_ALWAYS_HEADERS_* are set independed of status code
• remove hardcoded headers
• add unit test for headers
• replace integration tests:
   - add a mock web server
   - check HTTP status codes
   - check headers
   - check /tocco-status-nginx when Nice isn't running
• share host network with docker container to allow running
  webserver outside container
• call `nginx -t` in entrypoint script to get better error messages
• update README