### PR TITLE
remove incorrect HTTP headers

### DIFF
--- a/nice2.conf
+++ b/nice2.conf
@@ -6,7 +6,6 @@ server {
 
     add_header X-Cache $upstream_cache_status; # Request served by Cache?
     add_header X-AppServer-Status $upstream_status; # Backend HTTP Status
-    add_header X-AppServer $upstream_addr; # Backend Server / Port
 
     include       /etc/nginx/headers.include;
 
@@ -16,8 +15,6 @@ server {
         }
 
         proxy_pass http://localhost:8080;
-        proxy_set_header X-Forwarded-Proto $scheme;
-        proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header Host $http_host;
 


### PR DESCRIPTION
• remove X-AppServer:
     it is always localhost anyway
• remove X-Forwarded-Proto:
     this is only the schema used between HAProxy and Nginx
• remove X-Real-IP
     Nginx doesn't know the real IP