### PR TITLE
use gzip encoding for more types and for client requests

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -26,6 +26,9 @@ http {
     keepalive_timeout  65;
 
     gzip  on;
+    gzip_proxied any;
+    gzip_vary on;
+    gzip_types text/plain text/css application/json application/javascript application/x-javascript text/xml application/xml application/xml+rss text/javascript image/svg+xml;
 
     proxy_cache_path /var/cache/nginx levels=1:2:2 keys_zone=cache:256m inactive=1d max_size=2g;
 

--- a/nice2.conf
+++ b/nice2.conf
@@ -32,6 +32,5 @@ server {
         proxy_send_timeout 3s;
         proxy_http_version 1.1;
         proxy_set_header Connection "";
-        gzip_proxied any;
     }
 }


### PR DESCRIPTION
• move all gzip related configuration to nginx.conf
• enable Vary header (clients can send gzip compressed data now)
• enable gzip compression for more MIME types