### PR TITLE
remove no-cache and proxy bypass conditions

### DIFF
--- a/nice2.conf
+++ b/nice2.conf
@@ -24,8 +24,6 @@ server {
         proxy_cache_use_stale timeout updating error invalid_header http_500 http_502 http_503 http_504;
         proxy_cache_valid 4m;
         proxy_cache_valid 404 1m;
-        proxy_no_cache $cookie_nice_auth $http_authorization $cookie_nice_client_id;
-        proxy_cache_bypass $cookie_nice_auth $http_authorization $cookie_nice_client_id;
         proxy_next_upstream error timeout invalid_header http_500 http_502 http_503 http_504;
         proxy_read_timeout 30m;
         proxy_connect_timeout 3s;


### PR DESCRIPTION
Until now Nginx did not cache any data for logged in users. Including,
JS, CSS, icons and so on. (AFAIK, JS and CSS used to be cached when
content was still served directly from disk.) These files really
should be cached and if we don't want a resource to be cached the
HTTP headers should be set properly. As far as I can see, most
responses already contain correct expiry information and Browsers
did already cache anyway. Hence, I doubt this change is going to
cause much breakage.

---

@tstjep, @rzueger Is there any need to keep this hack around for Nice v2.10+? Caching is [controlled by Nice](https://git.tocco.ch/#/c/13829/) now, right?