### PR TITLE
allow body size up to 400 MiB

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -25,7 +25,7 @@ http {
     access_log  /var/log/nginx/access.log  main;
 
     sendfile        on;
-    #tcp_nopush     on;
+    client_max_body_size 400M;
 
     keepalive_timeout  65;
 


### PR DESCRIPTION
Default is 1 MiB but that's not enough for file upload.