### PR TITLE
increase client_body_buffer_size

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -48,7 +48,7 @@ http {
     server_tokens off;
 
     sendfile        on;
-    client_body_buffer_size 1M;
+    client_body_buffer_size 64K;
     client_max_body_size 400M;
 
     keepalive_timeout  65;

--- a/nginx.conf
+++ b/nginx.conf
@@ -48,6 +48,7 @@ http {
     server_tokens off;
 
     sendfile        on;
+    client_body_buffer_size 1M;
     client_max_body_size 400M;
 
     keepalive_timeout  65;


### PR DESCRIPTION
Only write body to disk once it exceeds 1 MiB (default is 16 KiB).