### PR TITLE
Disable proxy_next_upstream

### DIFF
--- a/nice2.conf
+++ b/nice2.conf
@@ -24,7 +24,7 @@ server {
         proxy_cache_use_stale timeout updating error invalid_header http_500 http_502 http_503 http_504;
         proxy_cache_valid 4m;
         proxy_cache_valid 404 1m;
-        proxy_next_upstream error timeout invalid_header http_500 http_502 http_503 http_504;
+        proxy_next_upstream off;
         proxy_read_timeout 30m;
         proxy_connect_timeout 3s;
         proxy_send_timeout 3s;


### PR DESCRIPTION
When proxy_next_upstream is enabled and the a request fails, Nginx
tries to connect to the next upstream. Since there is never a
second upstream in our setup, Nginx will start responding with
502s. This is fine if there a multiple upstreams but since there
is only ever one upstream, it's better to have Nginx just send
further request to the upstream anyway.