### PR TITLE
on error, do not serve 500.html or stale pages

### DIFF
--- a/nice2.conf
+++ b/nice2.conf
@@ -2,7 +2,6 @@ server {
     listen 8081;
 
     server_name _;
-    error_page 500 501 502 503 504 /500.html;
 
     add_header X-Cache $upstream_cache_status always; # Request served by Cache?
     add_header X-AppServer-Status $upstream_status always; # Backend HTTP Status
@@ -21,7 +20,6 @@ server {
         proxy_cache cache;
         proxy_cache_revalidate on;
         proxy_buffering on;
-        proxy_cache_use_stale timeout updating error invalid_header http_500 http_502 http_503 http_504;
         proxy_cache_valid 4m;
         proxy_cache_valid 404 1m;
         proxy_next_upstream off;


### PR DESCRIPTION
* do not serve 500.html: this file doesn't exist
* do not serve stale cache: in that case we want another pod to serve the request