### PR TITLE
adjust caching configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,6 @@ before_install:
         sleep 1;
     done
 script:
-  - docker exec nginx nginx -t
+  - docker exec nginx nginx -t || { docker logs nginx; false; }
   - PYTHONPATH=$PWD python3 -m unittest discover tests
   - ./tests/integration_tests.py

--- a/nginx.conf
+++ b/nginx.conf
@@ -59,7 +59,8 @@ http {
     gzip_types text/plain text/css application/json application/javascript application/x-javascript text/xml application/xml application/xml+rss text/javascript image/svg+xml;
 
     proxy_cache_key $http_x_forwarded_proto:$host$request_uri;
-    proxy_cache_path /var/cache/nginx levels=1:2:2 keys_zone=cache:256m inactive=1d max_size=2g;
+    proxy_cache_path /var/cache/nginx/proxy_cache levels=2 keys_zone=cache:10m inactive=1d max_size=2g;
+    proxy_temp_path /var/cache/nginx/proxy_temp/ 2;
 
     include /etc/nginx/conf.d/*.conf;
 }


### PR DESCRIPTION
• Use levels=2 to avoid creating too many subdirectories. We
  rarely have more than a few thousand items in cache.
• Reduce the size of shared memory used to keep cache keys in memory.
  10 MiB is enough for about 8,000 keys.