### PR TITLE
Upgrade requests to HTTPS.

### DIFF
--- a/nice2.conf.template
+++ b/nice2.conf.template
@@ -33,7 +33,12 @@ server {
             allow all;
             proxy_pass http://nice;
         }
+{% if NGINX_REDIRECT_TO_HTTPS|default(true) %}
+        if ($http_x_forwarded_proto = "http") {
+            return https://$host$request_uri;
+        }
 
+{% endif %}
         # WebSocket support
         proxy_set_header Upgrade $http_upgrade;
         proxy_set_header Connection $connection_upgrade;


### PR DESCRIPTION
Redirect HTTP requests to HTTPS by default. On OpenShift 3, we used
`insecureEdgeTerminationPolicy: Redirect` on routes but on OpenShift
4, with ingress being used, this functionality is no longer available.
So, let's do the redirect here instead.